### PR TITLE
Improved asymptote function fixes #115

### DIFF
--- a/assets/config/genesis.toml
+++ b/assets/config/genesis.toml
@@ -2,7 +2,8 @@ start_num = 20
 minimum_number = 5
 initial_synapse_count = 5
 mutations = 30
-start_energy = 800
+start_energy = 300
+lowest_energy_limit = 600
 rotation_cost = [
     0.02,
     0.1,

--- a/src/behaviour/thinking.rs
+++ b/src/behaviour/thinking.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn mind_thinks() {
-        config::initialize_config();
+        config::initialize_configs();
         let mut app = App::new();
 
         app.add_system(thinking_system);
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn mind_bundle_works() {
-        config::initialize_config();
+        config::initialize_configs();
 
         let mut app = App::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub struct GenesisPlugin;
 
 impl Plugin for GenesisPlugin {
     fn build(&self, app: &mut App) {
-        config::initialize_config();
+        config::initialize_configs();
 
         let config_instance = config::WorldConfig::global();
 


### PR DESCRIPTION
Energy limit now has an associated config struct which depends on other configurations.
If too much energy is passed to a bug's initialiser, it is returned to the ecosystem.