### PR TITLE
Allow input neurons to be biased

### DIFF
--- a/crates/genesis_brain/src/lib.rs
+++ b/crates/genesis_brain/src/lib.rs
@@ -302,15 +302,7 @@ impl Brain {
     }
 
     pub fn mutate_neuron_bias(&mut self) {
-        let mut non_input_neurons: Vec<&mut Neuron> = self
-            .neurons
-            .iter_mut()
-            .filter(|n| !matches!(n.kind(), NeuronKind::Input))
-            .collect();
-
-        let random_neuron = non_input_neurons
-            .choose_mut(&mut rand::thread_rng())
-            .unwrap();
+        let random_neuron = self.neurons.choose_mut(&mut rand::thread_rng()).unwrap();
 
         let offset: f32 = thread_rng().sample(StandardNormal);
         let new_bias =

--- a/crates/genesis_components/src/mind.rs
+++ b/crates/genesis_components/src/mind.rs
@@ -21,7 +21,7 @@ pub enum MindValidationError {
     ExpectedOutputNeuron(usize),
     #[error("Expected hidden neuron at index '{0}'.")]
     ExpectedHiddenNeuron(usize),
-    #[error("Invalid input neuron at index '{0}' it should have Identity activation function and bias 0.0.")]
+    #[error("Invalid input neuron at index '{0}' it should have Identity activation function.")]
     InputNeuronStructure(usize),
     #[error("Invalid output neuron at index '{0}' is should have Tanh activation function.")]
     OutputNeuronStructure(usize),
@@ -70,8 +70,7 @@ impl Mind {
             }
             // Check activation kind.
             if neuron.kind() == &NeuronKind::Input
-                && (neuron.activation() != &ActivationFunctionKind::Identity
-                    || neuron.bias().as_float() != 0.0)
+                && neuron.activation() != &ActivationFunctionKind::Identity
             {
                 return Err(MindValidationError::InputNeuronStructure(i));
             }


### PR DESCRIPTION
Fixes #178. Input neurons start with 0.0 bias but can be mutated.